### PR TITLE
fix(cua-driver): use qwen-code-assets OSS mirror, disable upload workflow

### DIFF
--- a/.github/workflows/sync-cua-driver-to-oss.yml
+++ b/.github/workflows/sync-cua-driver-to-oss.yml
@@ -1,16 +1,13 @@
 name: 'Sync cua-driver to Aliyun OSS'
 
-# Mirrors the pinned cua-driver-rs binaries from the upstream trycua/cua GitHub
-# release onto the hopcode-assets OSS bucket, so Computer Use's in-bootstrap
-# downloader can pull them fast from the CN mirror (with the trycua/cua GitHub
-# release as automatic fallback).
+# NOTE: This workflow is preserved for compatibility but is intentionally
+# no-op in the HopCode fork because we do not own the hopcode-assets OSS
+# bucket. The cua-driver downloader falls back to the qwen-code-assets OSS
+# mirror (populated by the upstream QwenLM/qwen-code repo) and the trycua/cua
+# GitHub release.
 #
-# Triggers:
-#   - push to main touching constants.ts (where CUA_DRIVER_VERSION lives), so a
-#     version bump auto-mirrors the new release without anyone remembering to.
-#     The "already mirrored" guard makes unrelated constants.ts edits a no-op.
-#   - manual workflow_dispatch (first-time / re-mirror; `force` re-uploads even
-#     when the version is already on OSS).
+# Triggers still fire on constants.ts changes, but the job exits immediately
+# without uploading anything.
 on:
   push:
     branches:
@@ -18,16 +15,6 @@ on:
     paths:
       - 'packages/core/src/tools/computer-use/constants.ts'
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'cua-driver-rs version to mirror (blank = read CUA_DRIVER_VERSION from constants.ts)'
-        required: false
-        type: 'string'
-      force:
-        description: 'Re-upload even if this version is already mirrored on OSS'
-        required: false
-        type: 'boolean'
-        default: false
 
 concurrency:
   group: 'sync-cua-driver-to-oss'
@@ -37,163 +24,8 @@ jobs:
   sync:
     name: 'Mirror cua-driver binaries to Aliyun OSS'
     runs-on: 'ubuntu-latest'
-    if: |-
-      ${{ github.repository == 'TaimoorSiddiquiOfficial/HopCode' }}
-    environment:
-      name: 'production-release'
-    permissions:
-      contents: 'read'
+    if: false
     steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
-
-      - name: 'Resolve cua-driver version'
-        id: 'meta'
-        env:
-          INPUT_VERSION: '${{ inputs.version }}'
+      - name: 'No-op in HopCode fork'
         run: |-
-          set -euo pipefail
-          version="${INPUT_VERSION:-}"
-          if [[ -z "${version}" ]]; then
-            version="$(grep -E "CUA_DRIVER_VERSION = '" packages/core/src/tools/computer-use/constants.ts \
-              | sed -E "s/.*'([0-9]+\.[0-9]+\.[0-9]+)'.*/\1/")"
-          fi
-          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Could not resolve a valid cua-driver version (got '${version}')."
-            exit 1
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "Resolved cua-driver-rs v${version}"
-
-      - name: 'Skip if this version is already mirrored'
-        id: 'guard'
-        env:
-          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://hopcode-assets.oss-cn-hangzhou.aliyuncs.com' }}"
-          VERSION: '${{ steps.meta.outputs.version }}'
-          FORCE: '${{ inputs.force }}'
-        run: |-
-          set -euo pipefail
-          url="${ALIYUN_OSS_PUBLIC_BASE_URL}/computer-use/cua-driver-rs/v${VERSION}/checksums.txt"
-          if [[ "${FORCE}" != "true" ]] && curl -fsI --connect-timeout 15 --max-time 60 "${url}" >/dev/null 2>&1; then
-            echo "v${VERSION} already mirrored (${url}); nothing to do. Re-run with force=true to overwrite."
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "v${VERSION} not yet on OSS (or force=true); will mirror."
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: 'Download the assets hopcode consumes from trycua/cua'
-        if: |-
-          ${{ steps.guard.outputs.skip != 'true' }}
-        env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          VERSION: '${{ steps.meta.outputs.version }}'
-        run: |-
-          set -euo pipefail
-          mkdir -p dist/cua-driver
-          # Only the per-platform assets resolveAssetTarget() can request, plus
-          # checksums.txt. Keep aligned with constants.ts resolveAssetTarget().
-          gh release download "cua-driver-rs-v${VERSION}" \
-            --repo trycua/cua \
-            --dir dist/cua-driver \
-            --pattern "cua-driver-rs-${VERSION}-darwin-arm64.tar.gz" \
-            --pattern "cua-driver-rs-${VERSION}-darwin-x86_64.tar.gz" \
-            --pattern "cua-driver-rs-${VERSION}-linux-x86_64-binary.tar.gz" \
-            --pattern "cua-driver-rs-${VERSION}-windows-x86_64.zip" \
-            --pattern "cua-driver-rs-${VERSION}-windows-arm64.zip" \
-            --pattern "checksums.txt"
-          ls -la dist/cua-driver
-
-      - name: 'Verify checksums before upload'
-        if: |-
-          ${{ steps.guard.outputs.skip != 'true' }}
-        run: |-
-          set -euo pipefail
-          cd dist/cua-driver
-          # checksums.txt lists every release asset; --ignore-missing checks
-          # only the ones we pulled. A mismatch fails the sync before upload.
-          sha256sum -c --ignore-missing checksums.txt
-
-      - name: 'Install ossutil'
-        if: |-
-          ${{ steps.guard.outputs.skip != 'true' }}
-        env:
-          OSSUTIL_URL: "${{ vars.OSSUTIL_URL || 'https://gosspublic.alicdn.com/ossutil/1.7.19/ossutil-v1.7.19-linux-amd64.zip' }}"
-          OSSUTIL_SHA256: "${{ vars.OSSUTIL_SHA256 || 'dcc512e4a893e16bbee63bc769339d8e56b21744fd83c8212a9d8baf28767343' }}"
-        run: |-
-          set -euo pipefail
-          tmp_dir="$(mktemp -d)"
-          curl -fsSL --connect-timeout 15 --max-time 300 "${OSSUTIL_URL}" -o "${tmp_dir}/ossutil.zip"
-          echo "${OSSUTIL_SHA256}  ${tmp_dir}/ossutil.zip" | sha256sum -c -
-          unzip -q "${tmp_dir}/ossutil.zip" -d "${tmp_dir}"
-          ossutil_path="$(find "${tmp_dir}" -type f \( -name 'ossutil' -o -name 'ossutil64' \) -print -quit)"
-          if [[ -z "${ossutil_path}" ]]; then
-            echo "::error::ossutil binary not found in downloaded archive"
-            exit 1
-          fi
-          chmod +x "${ossutil_path}"
-          mkdir -p "${HOME}/.local/bin"
-          install -m 0755 "${ossutil_path}" "${HOME}/.local/bin/ossutil"
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-          rm -rf "${tmp_dir}"
-          "${HOME}/.local/bin/ossutil" >/dev/null
-
-      - name: 'Configure Aliyun OSS Credentials'
-        if: |-
-          ${{ steps.guard.outputs.skip != 'true' }}
-        env:
-          ALIYUN_OSS_ACCESS_KEY_ID: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}'
-          ALIYUN_OSS_ACCESS_KEY_SECRET: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}'
-          ALIYUN_OSS_ENDPOINT: "${{ vars.ALIYUN_OSS_ENDPOINT || 'https://oss-cn-hangzhou.aliyuncs.com' }}"
-        run: |-
-          set -euo pipefail
-          if [[ -z "${ALIYUN_OSS_ACCESS_KEY_ID}" || -z "${ALIYUN_OSS_ACCESS_KEY_SECRET}" ]]; then
-            echo "::error::Missing Aliyun OSS credentials. Set ALIYUN_OSS_ACCESS_KEY_ID and ALIYUN_OSS_ACCESS_KEY_SECRET in the production-release environment secrets."
-            exit 1
-          fi
-          ossutil config \
-            -e "${ALIYUN_OSS_ENDPOINT}" \
-            -i "${ALIYUN_OSS_ACCESS_KEY_ID}" \
-            -k "${ALIYUN_OSS_ACCESS_KEY_SECRET}" \
-            -L EN \
-            -c "${RUNNER_TEMP}/.ossutilconfig"
-
-      - name: 'Upload to Aliyun OSS'
-        if: |-
-          ${{ steps.guard.outputs.skip != 'true' }}
-        env:
-          ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'hopcode-assets' }}"
-          VERSION: '${{ steps.meta.outputs.version }}'
-        run: |-
-          set -euo pipefail
-          # Prefix mirrors resolveAssetUrls(): <base>/cua-driver-rs/v<ver>/<asset>,
-          # where OSS_MIRROR_BASE already carries the `computer-use` segment.
-          node scripts/upload-aliyun-oss-assets.js \
-            --bucket "${ALIYUN_OSS_BUCKET}" \
-            --config "${RUNNER_TEMP}/.ossutilconfig" \
-            --prefix "computer-use/cua-driver-rs/v${VERSION}" \
-            dist/cua-driver/*
-
-      - name: 'Verify assets are reachable + intact on OSS'
-        if: |-
-          ${{ steps.guard.outputs.skip != 'true' }}
-        env:
-          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://hopcode-assets.oss-cn-hangzhou.aliyuncs.com' }}"
-          VERSION: '${{ steps.meta.outputs.version }}'
-        run: |-
-          set -euo pipefail
-          base="${ALIYUN_OSS_PUBLIC_BASE_URL}/computer-use/cua-driver-rs/v${VERSION}"
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "${tmp_dir}"' EXIT
-          for path in dist/cua-driver/*; do
-            f="$(basename "${path}")"
-            curl -fsSL --connect-timeout 15 --max-time 300 "${base}/${f}" -o "${tmp_dir}/${f}"
-          done
-          cd "${tmp_dir}"
-          sha256sum -c --ignore-missing checksums.txt
-          echo "All mirrored cua-driver assets verified on OSS at ${base}/"
-
-      - name: 'Cleanup Aliyun OSS Credentials'
-        if: '${{ always() }}'
-        run: |-
-          rm -f "${RUNNER_TEMP}/.ossutilconfig"
+          echo 'Skipping OSS mirror — HopCode uses the qwen-code-assets public mirror.'

--- a/packages/core/src/tools/computer-use/constants.ts
+++ b/packages/core/src/tools/computer-use/constants.ts
@@ -12,9 +12,11 @@
  * Unlike the previous open-computer-use backend, cua-driver is NOT on npm.
  * It ships as per-platform, Developer-ID-signed + Apple-notarized binaries
  * attached to GitHub releases (tag `cua-driver-rs-v<version>`). We download
- * the pinned asset once into `~/.qwen/computer-use/`, preferring a
- * hopcode-owned OSS mirror (reliable in CN where GitHub release downloads
- * are slow/blocked) and falling back to GitHub.
+ * the pinned asset once into `~/.hopcode/computer-use/`, preferring the
+ * qwen-code-assets OSS mirror (reliable in CN where GitHub release downloads
+ * are slow/blocked) and falling back to the upstream GitHub release.
+ * Enterprises can override the host via `HOPCODE_COMPUTER_USE_DOWNLOAD_HOST`
+ * to point at an internal mirror.
  *
  * Source: https://github.com/trycua/cua/tree/main/libs/cua-driver
  * License: MIT (the driver pulls no AGPL deps — AGPL only affects the
@@ -34,30 +36,26 @@ import { homedir } from 'node:os';
  * can't silently drift our hardcoded schemas or break the download.
  *
  * To bump: update this, re-run `scripts/sync-computer-use-schemas.ts`
- * against the new binary, sync the new assets to OSS via
- * `scripts/sync-cua-driver-to-oss.ts`, then smoke-test on macOS.
+ * against the new binary, then smoke-test on macOS.
  */
 export const CUA_DRIVER_VERSION = '0.5.2';
 
 /**
- * hopcode-owned OSS mirror base (primary download source — reliable in CN
- * where GitHub release downloads are slow/blocked). Assets live under
- * `<base>/cua-driver-rs/v<version>/<asset>`, mirrored from the upstream
- * trycua/cua release by the "Sync cua-driver to Aliyun OSS" workflow
- * (.github/workflows/sync-cua-driver-to-oss.yml), which auto-triggers on pushes
- * to main that touch this file — a CUA_DRIVER_VERSION bump auto-mirrors the new
- * release (a checksums.txt guard no-ops when already mirrored); manual
- * workflow_dispatch covers first-time / forced re-mirror. Until a version is
- * mirrored there, the GitHub fallback (GITHUB_RELEASE_BASE) serves it
- * transparently.
+ * Shared qwen-code-assets OSS mirror base (reliable in CN where GitHub release
+ * downloads are slow/blocked). Assets live under
+ * `<base>/cua-driver-rs/v<version>/<asset>` and are mirrored from the upstream
+ * trycua/cua release by the Qwen project. The HopCode fork consumes this same
+ * public mirror because we do not operate our own OSS bucket.
  *
- * Hosted on the shared `hopcode-assets` bucket (same one the CLI's own
- * release/installation assets use), under a `computer-use` namespace.
+ * The upstream workflow that populates this mirror is
+ * `.github/workflows/sync-cua-driver-to-oss.yml` in the QwenLM/qwen-code repo.
  */
 export const OSS_MIRROR_BASE =
-  'https://hopcode-assets.oss-cn-hangzhou.aliyuncs.com/computer-use';
+  'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/computer-use';
 
-/** GitHub release download base for the pinned tag (fallback source). */
+/**
+ * GitHub release download base for the pinned tag (fallback source).
+ */
 export const GITHUB_RELEASE_BASE =
   'https://github.com/trycua/cua/releases/download';
 
@@ -140,8 +138,8 @@ export function resolveAssetTarget(
 
 /**
  * Ordered list of full download URLs for an asset: env override (if set),
- * then OSS mirror, then GitHub. The downloader tries each in order until
- * one succeeds.
+ * then the qwen-code-assets OSS mirror, then GitHub. The downloader tries each
+ * in order until one succeeds.
  *
  * `HOPCODE_COMPUTER_USE_DOWNLOAD_HOST` lets enterprises / power users point at
  * an internal mirror laid out like OSS (`<host>/cua-driver-rs/v<ver>/<asset>`).


### PR DESCRIPTION
HopCode does not own the hopcode-assets Aliyun OSS bucket. This change points cua-driver downloads at the existing qwen-code-assets public mirror (with GitHub release fallback) and disables the sync-cua-driver-to-oss workflow in our repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact download mirror to utilize a shared public repository source for enhanced accessibility and reliability.
  * Streamlined internal artifact synchronization workflows, reducing operational complexity while maintaining consistent asset delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->